### PR TITLE
feat(phase5): API hardening - /version, trace persistence, demo script

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       contents: read
       id-token: write  # Required for Workload Identity Federation
+    outputs:
+      service_url: ${{ steps.get-url.outputs.url }}
 
     steps:
     - uses: actions/checkout@v4
@@ -38,7 +40,11 @@ jobs:
 
     - name: Build Docker image
       run: |
-        docker build -t ${{ env.REGISTRY }}/${{ env.GCP_PROJECT }}/sdlc/${{ env.SERVICE_NAME }}:${{ github.sha }} .
+        BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        docker build \
+          --build-arg GIT_SHA=${{ github.sha }} \
+          --build-arg BUILD_TIME=${BUILD_TIME} \
+          -t ${{ env.REGISTRY }}/${{ env.GCP_PROJECT }}/sdlc/${{ env.SERVICE_NAME }}:${{ github.sha }} .
         docker tag ${{ env.REGISTRY }}/${{ env.GCP_PROJECT }}/sdlc/${{ env.SERVICE_NAME }}:${{ github.sha }} \
                    ${{ env.REGISTRY }}/${{ env.GCP_PROJECT }}/sdlc/${{ env.SERVICE_NAME }}:staging
 
@@ -60,10 +66,61 @@ jobs:
           GCP_LOCATION=us-central1
           VERTEX_LLM_MODEL=gemini-1.5-flash
           VERTEX_EMBED_MODEL=text-embedding-005
+          GIT_SHA=${{ github.sha }}
 
-    - name: Show deployment URL
+    - name: Get service URL
+      id: get-url
       run: |
-        echo "✅ Deployed to Cloud Run"
-        gcloud run services describe ${{ env.SERVICE_NAME }} \
+        URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
           --region=${{ env.GCP_REGION }} \
-          --format='value(status.url)'
+          --format='value(status.url)')
+        echo "url=${URL}" >> $GITHUB_OUTPUT
+        echo "✅ Deployed to: ${URL}"
+
+  smoke-check:
+    needs: build-push-deploy
+    runs-on: ubuntu-latest
+    steps:
+    - name: Health check with retries
+      run: |
+        SERVICE_URL="${{ needs.build-push-deploy.outputs.service_url }}"
+        echo "Checking health at ${SERVICE_URL}/health"
+        for i in 1 2 3 4 5; do
+          echo "Attempt $i..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${SERVICE_URL}/health" || echo "000")
+          if [ "$STATUS" = "200" ]; then
+            echo "✅ Health check passed"
+            break
+          fi
+          if [ $i -eq 5 ]; then
+            echo "❌ Health check failed after 5 attempts"
+            exit 1
+          fi
+          echo "Status: $STATUS, retrying in $((i * 5))s..."
+          sleep $((i * 5))
+        done
+
+    - name: Version check
+      run: |
+        SERVICE_URL="${{ needs.build-push-deploy.outputs.service_url }}"
+        echo "Checking version at ${SERVICE_URL}/version"
+        RESPONSE=$(curl -sf "${SERVICE_URL}/version")
+        echo "Response: ${RESPONSE}"
+
+        # Verify git_sha is present and matches
+        GIT_SHA=$(echo "$RESPONSE" | jq -r '.git_sha')
+        if [ "$GIT_SHA" = "null" ] || [ -z "$GIT_SHA" ]; then
+          echo "❌ git_sha missing from /version response"
+          exit 1
+        fi
+        echo "✅ git_sha: ${GIT_SHA}"
+
+        # Verify app_env
+        APP_ENV=$(echo "$RESPONSE" | jq -r '.app_env')
+        if [ "$APP_ENV" != "staging" ]; then
+          echo "❌ Expected app_env=staging, got ${APP_ENV}"
+          exit 1
+        fi
+        echo "✅ app_env: ${APP_ENV}"
+
+        echo "✅ Version check passed"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Use official Python runtime as base image
 FROM python:3.11-slim
 
+# Build arguments
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+
 # Set working directory
 WORKDIR /app
 
@@ -19,12 +23,16 @@ RUN pip install --no-cache-dir -r services/api/requirements.txt
 COPY packages/ /app/packages/
 COPY services/ /app/services/
 
-# Create storage directory
-RUN mkdir -p /app/services/api/storage/contexts
+# Create storage directories
+RUN mkdir -p /app/services/api/storage/contexts \
+    /app/services/api/storage/datasets \
+    /app/services/api/storage/traces
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 ENV PORT=8080
+ENV GIT_SHA=${GIT_SHA}
+ENV BUILD_TIME=${BUILD_TIME}
 
 # Expose port
 EXPOSE 8080
@@ -35,4 +43,3 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 
 # Run the application
 CMD ["uvicorn", "services.api.main:app", "--host", "0.0.0.0", "--port", "8080"]
-

--- a/scripts/demo_staging.sh
+++ b/scripts/demo_staging.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Demo script for staging environment
+# Usage: ./scripts/demo_staging.sh
+# Override base URL: STAGING_BASE_URL=https://... ./scripts/demo_staging.sh
+
+set -e
+
+# Default staging URL
+STAGING_BASE_URL="${STAGING_BASE_URL:-https://sdlc-api-staging-du6qod3mja-uc.a.run.app}"
+
+echo "=== SDLC API Staging Demo ==="
+echo "Base URL: ${STAGING_BASE_URL}"
+echo ""
+
+# Step 1: Health check
+echo ">>> Step 1: Health check"
+HEALTH=$(curl -sf "${STAGING_BASE_URL}/health")
+echo "Response: ${HEALTH}"
+echo ""
+
+# Step 2: Version check
+echo ">>> Step 2: Version check"
+VERSION=$(curl -sf "${STAGING_BASE_URL}/version")
+echo "Response: ${VERSION}"
+GIT_SHA=$(echo "$VERSION" | jq -r '.git_sha')
+APP_ENV=$(echo "$VERSION" | jq -r '.app_env')
+echo "Git SHA: ${GIT_SHA}"
+echo "App Env: ${APP_ENV}"
+echo ""
+
+# Step 3: Upload context document
+echo ">>> Step 3: Upload context document"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+DOCX_PATH="${PROJECT_ROOT}/docs/samples/context_template.docx"
+
+if [ ! -f "$DOCX_PATH" ]; then
+    echo "ERROR: Context document not found at ${DOCX_PATH}"
+    exit 1
+fi
+
+UPLOAD_DOC=$(curl -sf -X POST "${STAGING_BASE_URL}/upload_context_doc" \
+    -F "file=@${DOCX_PATH}")
+echo "Response: ${UPLOAD_DOC}"
+DOC_ID=$(echo "$UPLOAD_DOC" | jq -r '.doc_id')
+echo "Doc ID: ${DOC_ID}"
+echo ""
+
+# Step 4: Upload dataset
+echo ">>> Step 4: Upload dataset"
+CSV_PATH="${PROJECT_ROOT}/services/api/tests/fixtures/causal_binary_treatment.csv"
+
+if [ ! -f "$CSV_PATH" ]; then
+    echo "ERROR: Dataset not found at ${CSV_PATH}"
+    exit 1
+fi
+
+UPLOAD_DS=$(curl -sf -X POST "${STAGING_BASE_URL}/upload_dataset" \
+    -F "file=@${CSV_PATH}")
+echo "Response: ${UPLOAD_DS}"
+DATASET_ID=$(echo "$UPLOAD_DS" | jq -r '.dataset_id')
+echo "Dataset ID: ${DATASET_ID}"
+echo ""
+
+# Step 5a: Causal question WITHOUT confirmations
+echo ">>> Step 5a: Causal question WITHOUT confirmations (expect NEEDS_CLARIFICATION or diagnostics)"
+ASK_NO_CONFIRM=$(curl -sf -X POST "${STAGING_BASE_URL}/ask" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"question\": \"What is the causal effect of treatment on outcome?\",
+        \"doc_id\": \"${DOC_ID}\",
+        \"dataset_id\": \"${DATASET_ID}\",
+        \"causal_spec_override\": {
+            \"treatment\": \"treatment\",
+            \"outcome\": \"outcome\",
+            \"confounders\": [\"age\", \"income\", \"prior_purchases\"]
+        }
+    }")
+echo "Response (trimmed):"
+echo "$ASK_NO_CONFIRM" | jq '{route: .router_decision.route, trace_id: .trace_id, artifact_types: [.artifacts[].type]}'
+TRACE_ID_1=$(echo "$ASK_NO_CONFIRM" | jq -r '.trace_id')
+echo "Trace ID: ${TRACE_ID_1}"
+echo ""
+
+# Step 5b: Causal question WITH confirmations
+echo ">>> Step 5b: Causal question WITH confirmations (expect CausalEstimateArtifact)"
+ASK_WITH_CONFIRM=$(curl -sf -X POST "${STAGING_BASE_URL}/ask" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"question\": \"What is the causal effect of treatment on outcome?\",
+        \"doc_id\": \"${DOC_ID}\",
+        \"dataset_id\": \"${DATASET_ID}\",
+        \"causal_spec_override\": {
+            \"treatment\": \"treatment\",
+            \"outcome\": \"outcome\",
+            \"confounders\": [\"age\", \"income\", \"prior_purchases\"]
+        },
+        \"causal_confirmations\": {
+            \"assignment_mechanism\": \"randomized\",
+            \"interference\": \"no_interference\",
+            \"missing_data_policy\": \"listwise_delete\",
+            \"ok_to_estimate\": true
+        }
+    }")
+echo "Response (trimmed):"
+echo "$ASK_WITH_CONFIRM" | jq '{route: .router_decision.route, trace_id: .trace_id, artifact_types: [.artifacts[].type]}'
+TRACE_ID_2=$(echo "$ASK_WITH_CONFIRM" | jq -r '.trace_id')
+echo "Trace ID: ${TRACE_ID_2}"
+
+# Check for causal estimate
+ESTIMATE=$(echo "$ASK_WITH_CONFIRM" | jq '.artifacts[] | select(.type == "causal_estimate")')
+if [ -n "$ESTIMATE" ]; then
+    echo ""
+    echo ">>> Causal Estimate Found:"
+    echo "$ESTIMATE" | jq '{method, estimate, ci_low, ci_high, n_used}'
+else
+    echo ""
+    echo ">>> No causal estimate in response (may need dataset with proper treatment)"
+fi
+
+echo ""
+echo "=== Demo Complete ==="
+echo "Trace IDs:"
+echo "  - Without confirmations: ${TRACE_ID_1}"
+echo "  - With confirmations: ${TRACE_ID_2}"
+

--- a/services/api/tests/test_upload_context_doc.py
+++ b/services/api/tests/test_upload_context_doc.py
@@ -155,3 +155,22 @@ def test_health_endpoint():
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
+
+def test_version_endpoint():
+    """Test that version endpoint returns expected fields."""
+    response = client.get("/version")
+    assert response.status_code == 200
+
+    data = response.json()
+    # Verify required fields are present
+    assert "git_sha" in data
+    assert "build_time" in data
+    assert "app_env" in data
+
+    # Verify types
+    assert isinstance(data["git_sha"], str)
+    assert isinstance(data["build_time"], str)
+    assert isinstance(data["app_env"], str)
+
+    # In test environment, app_env should be dev
+    assert data["app_env"] == "dev"


### PR DESCRIPTION
## Phase 5: API Hardening

### Changes
- **GET /version endpoint**: Returns git_sha, build_time, app_env for deployment verification
- **Trace persistence**: Every /ask call persists trace to storage/traces/{trace_id}.json
- **Post-deploy smoke check**: deploy_staging.yml now verifies /health and /version after deploy
- **Demo script**: scripts/demo_staging.sh for staging demos
- **Tests**: Added tests for /version and trace persistence
- **Docs**: Updated DEPLOYMENT.md with operations info

### Trace File Contents
- trace_id, timestamp, route, doc_id, dataset_id
- router_decision (route, confidence, reasons)
- retrieved_chunk_ids (sorted list)
- diagnostics_summary (PASS/WARN/FAIL counts + key failures)
- estimator_selected, n_used, estimate, ci_low, ci_high (if estimation ran)
- artifact_inventory (list of artifact types with sizes)

### Testing
- All 36 tests pass
- ruff clean
- Docker build verified